### PR TITLE
fix: usr: fixes `ld: file not found:` error for `GhostWord.app/GhostWord`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.xcuserstate

--- a/GhostWords.xcodeproj/project.pbxproj
+++ b/GhostWords.xcodeproj/project.pbxproj
@@ -463,7 +463,7 @@
 		3F92829619AA85E6000D3791 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/GhostWord.app/GhostWord";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/GhostWords.app/GhostWords";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -482,7 +482,7 @@
 		3F92829719AA85E6000D3791 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/GhostWord.app/GhostWord";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/GhostWords.app/GhostWords";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",


### PR DESCRIPTION
`it should be`GhostWords.app/GhostWords`
